### PR TITLE
docs: 백엔드 주식 및 파티 API 명세 추가

### DIFF
--- a/app/koi-server/README.md
+++ b/app/koi-server/README.md
@@ -70,8 +70,57 @@ KOI-SERVER는 파티 게임 플랫폼의 백엔드 애플리케이션입니다. 
   ```
   `.env` 파일의 환경 변수 키와 값이 올바르게 설정되어 있는지 확인하세요.
 
+## API 명세
 
-5. 프로덕션 빌드
-    ```bash
-    yarn build
+### 주식 API
+
+> sdc-stock/package/feature/feature-nest-stock 의 README.md 참고
+
+### 파티 API
+
+#### 파티 조회
+- **GET** `/party/query`
+  - 모든 파티 목록을 조회합니다
+  - 응답: `Party[]`
+
+- **GET** `/party/query/:partyId`
+  - 특정 파티의 상세 정보를 조회합니다
+  - 파라미터:
+    - `partyId`: 파티 ID
+  - 응답: `Party`
+
+#### 파티 생성
+- **POST** `/party`
+  - 새로운 파티를 생성합니다
+
+#### 파티 참가/탈퇴
+- **POST** `/party/join`
+  - 파티에 참가합니다
+  - 요청 본문:
+    ```typescript
+    {
+      partyId: string;
+      userId: string;
+    }
     ```
+
+- **POST** `/party/leave`
+  - 파티에서 탈퇴합니다
+  - 요청 본문:
+    ```typescript
+    {
+      partyId: string;
+      userId: string;
+    }
+    ```
+  - 응답: `Party`
+
+#### 파티 수정/삭제
+- **PATCH** `/party`
+  - 파티 정보를 수정합니다
+
+- **DELETE** `/party`
+  - 파티를 삭제합니다
+  - 쿼리 파라미터:
+    - `partyId`: 삭제할 파티 ID
+  - 응답: `boolean`

--- a/app/koi-server/README.md
+++ b/app/koi-server/README.md
@@ -74,7 +74,7 @@ KOI-SERVER는 파티 게임 플랫폼의 백엔드 애플리케이션입니다. 
 
 ### 주식 API
 
-> sdc-stock/package/feature/feature-nest-stock 의 README.md 참고
+> [sdc-stock/package/feature/feature-nest-stock의 README.md](https://github.com/omizha/sdc-stock/blob/main/package/feature/feature-nest-stock/README.md) 참고
 
 ### 파티 API
 

--- a/app/koi-server/README.md
+++ b/app/koi-server/README.md
@@ -92,6 +92,7 @@ KOI-SERVER는 파티 게임 플랫폼의 백엔드 애플리케이션입니다. 
 #### 파티 생성
 - **POST** `/party`
   - 새로운 파티를 생성합니다
+  - 응답: `Party`
 
 #### 파티 참가/탈퇴
 - **POST** `/party/join`
@@ -102,6 +103,7 @@ KOI-SERVER는 파티 게임 플랫폼의 백엔드 애플리케이션입니다. 
       partyId: string;
       userId: string;
     }
+   - 응답: `Party`
     ```
 
 - **POST** `/party/leave`

--- a/package/feature/feature-nest-stock/README.md
+++ b/package/feature/feature-nest-stock/README.md
@@ -1,0 +1,63 @@
+# Feature Nest Stock
+
+NestJS 주식 게임 기능입니다.
+
+## 기능
+
+- 주식 거래 시스템
+- 사용자 관리
+- 거래 로그 기록
+- 게임 결과 저장
+
+## 주요 모듈
+
+### Stock Module
+- 주식 거래의 핵심 기능 담당
+- 주식 생성, 구매, 판매, 초기화 등의 기능 제공
+- 실시간 주가 변동 처리
+
+### User Module
+- 사용자 정보 관리
+- 사용자별 주식 보유 현황 및 자산 관리
+- 사용자 추가/삭제 기능
+
+### Log Module
+- 모든 거래 내역 기록
+- 거래 시간, 종목, 수량, 가격 등 상세 정보 저장
+
+### Result Module
+- 게임 결과 저장 및 조회
+- 라운드별 사용자 순위 및 수익률 기록
+
+## 기술 스택
+
+- NestJS
+- MongoDB (Mongoose)
+
+## API 엔드포인트
+
+### Stock
+- `GET /stock/list` - 모든 주식 세션 조회
+- `GET /stock?stockId={stockId}` - 특정 주식 세션 조회
+- `GET /stock/phase?stockId={stockId}` - 특정 주식 세션의 현재 상태 조회
+- `POST /stock/create` - 새로운 주식 세션 생성
+- `PATCH /stock?stockId={stockId}` - 특정 주식 세션 수정
+- `POST /stock/reset?stockId={stockId}` - 특정 주식 세션 리셋
+- `POST /stock/result?stockId={stockId}` - 특정 주식 세션의 결과 저장
+- `POST /stock/init?stockId={stockId}` - 특정 주식 세션 초기 환경 세팅
+- `POST /stock/buy` - 주식 구매
+- `POST /stock/sell` - 주식 판매
+- `POST /stock/finish?stockId={stockId}` - 특정 주식 세션 거래 정지 후, 모든 사용자 주식 판매
+
+### User
+- `GET /stock/user` - 사용자 목록 조회
+- `POST /stock/user` - 사용자 추가
+- `DELETE /stock/user` - 사용자 삭제'
+- `DELETE /stock/user/all?stockId={stockId}` - 특정 주식 세션의 모든 사용자 삭제
+
+### Log
+- `GET /stock/log?stockId={stockId}&userId={userId}` - 거래 로그 조회
+
+### Result
+- `GET /stock/result?stockId={stockId}` - 게임 결과 조회
+```


### PR DESCRIPTION

- `app/koi-server/README.md`에 주식 및 파티 API 명세 추가
  - 주식 API는 `sdc-stock/package/feature/feature-nest-stock`의 README.md를 참고하도록 안내
  - 파티 API에 대한 상세 설명 추가
    - 파티 조회, 생성, 참가/탈퇴, 수정/삭제에 대한 엔드포인트 및 요청/응답 형식 설명
- `package/feature/feature-nest-stock/README.md` 파일 생성 및 주식 게임 기능에 대한 설명 추가
  - 기능, 주요 모듈, 기술 스택, API 엔드포인트에 대한 상세 설명 포함
  - 주식, 사용자, 거래 로그, 게임 결과 관련 API 엔드포인트 설명 추가
