### PR TITLE
feat: 주식 게임 초기화 로직 개선 및 상수 분리

### DIFF
--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -92,7 +92,10 @@ export class StockService {
     const newCompanies = {} as Record<stock.CompanyNames, CompanyInfo[]>;
     const playerIdxs = [...Array(players.length).keys()];
 
+    // 플레이어에게 줄 정보의 절반 개수
     const halfInfoCount = Math.min(Math.max(Math.floor(90 / players.length), 1), 3);
+
+    // 플레이어에게 줄 정보를 랜덤하게 주기 위한 배열
     const randomPlayers = [...Array(halfInfoCount).keys()]
       .map(() => playerIdxs)
       .flat()

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -88,10 +88,15 @@ export class StockService {
     const stock = await this.stockRepository.findOneById(stockId);
     const players = await this.userService.getUserList(stockId);
 
+    const companyPriceChange: string[][] = [[]];
     const newCompanies = {} as Record<stock.CompanyNames, CompanyInfo[]>;
     const playerIdxs = [...Array(players.length).keys()];
-    const randomPlayers = [...playerIdxs, ...playerIdxs, ...playerIdxs].sort(() => Math.random() - 0.5);
-    const companyPriceChange: string[][] = [[]];
+
+    const halfInfoCount = players.length > 30 ? Math.floor(90 / players.length) : 3;
+    const randomPlayers = [...Array(halfInfoCount).keys()]
+      .map(() => playerIdxs)
+      .flat()
+      .sort(() => Math.random() - 0.5);
 
     // 라운드 별 주가 변동 회사 선정
     for (let round = 1; round < 10; round++) {

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -93,6 +93,9 @@ export class StockService {
     const playerIdxs = Array.from({ length: players.length }, (_, idx) => idx);
 
     // 플레이어에게 줄 정보의 절반 개수
+    // 플레이어 수 00명 ~ 30명 : 3개 (*2 = 6개)
+    // 플레이어 수 31명 ~ 60명 : 2개 (*2 = 4개)
+    // 플레이어 수 61명 ~     : 1개 (*2 = 2개)
     const halfInfoCount = Math.min(Math.max(Math.floor(90 / players.length), 1), 3);
 
     // 플레이어에게 줄 정보를 랜덤하게 주기 위한 배열

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -6,6 +6,7 @@ import { ceilToUnit } from '@toss/utils';
 import mongoose, { ProjectionType, QueryOptions } from 'mongoose';
 import { InjectConnection } from '@nestjs/mongoose';
 import dayjs from 'dayjs';
+import { INIT_STOCK_PRICE } from 'shared~config/dist/stock';
 import { Stock, StockDocument } from './stock.schema';
 import { UserService } from './user/user.service';
 import { LogService } from './log/log.service';
@@ -91,53 +92,58 @@ export class StockService {
     const playerIdxs = [...Array(players.length).keys()];
     const randomPlayers = [...playerIdxs, ...playerIdxs, ...playerIdxs].sort(() => Math.random() - 0.5);
     const companyPriceChange: string[][] = [[]];
-    // 1:00 ~ 1:45
-    for (let i = 1; i < 10; i++) {
-      companyPriceChange[i] = [...Config.Stock.getRandomCompanyNames(Math.ceil(players.length / 3))];
+
+    // 라운드 별 주가 변동 회사 선정
+    for (let round = 1; round < 10; round++) {
+      // 라운드당 (플레이어 수의 1/3) 만큼의 회사가 선정되며, 최대 10개로 제한됩니다 (전체 회사가 10개라서)
+      const companyCount = Math.ceil(players.length / 3);
+      const limitedCompanyCount = companyCount > 10 ? 10 : companyCount;
+      companyPriceChange[round] = [...Config.Stock.getRandomCompanyNames(limitedCompanyCount)];
     }
 
+    // 라운드별 주식의 가격을 설정하고, 플레이어에게 정보 제공
     Config.Stock.getRandomCompanyNames().forEach((key) => {
       const company = key as stock.CompanyNames;
-      // 1:00 ~ 1:45
-      for (let i = 0; i < 10; i++) {
+      for (let round = 0; round < 10; round++) {
         if (!newCompanies[company]) {
           newCompanies[company] = [];
         }
 
-        if (i === 0) {
+        if (round === 0) {
           newCompanies[company][0] = {
-            가격: 100000,
+            가격: INIT_STOCK_PRICE,
             정보: [],
           };
-        } else {
-          const isChange = companyPriceChange[i].some((v) => v === key);
-          const prevPrice = newCompanies[company][i - 1].가격;
-          // const price = isChange ? prevPrice + (Math.floor(Math.random() * 1000) - 500) * 100 : prevPrice;
-          // const price = prevPrice + (Math.floor(Math.random() * 1000) - 500) * 100;
-
-          const calc1 = Math.floor(Math.random() * prevPrice - prevPrice / 2);
-          const calc2 = Math.floor(Math.random() * 100000 - 50000);
-
-          const frunc = Math.abs(calc1) >= Math.abs(calc2) ? calc1 : prevPrice + calc2 <= 0 ? calc1 : calc2;
-          const price = ceilToUnit(prevPrice + frunc, 100);
-          const info = [];
-
-          if (isChange) {
-            const infoPlayerIdx = randomPlayers.pop();
-            if (infoPlayerIdx !== undefined) {
-              const partnerPlayerIdx = (infoPlayerIdx + stock.round + 1) % players.length;
-              info.push(players[infoPlayerIdx].userId, players[partnerPlayerIdx].userId);
-            }
-          }
-
-          newCompanies[company][i] = {
-            가격: price,
-            정보: info,
-          };
+          continue;
         }
+
+        const isChangePrice = companyPriceChange[round].some((v) => v === key);
+        const prevPrice = newCompanies[company][round - 1].가격;
+
+        const calc1 = Math.floor(Math.random() * prevPrice - prevPrice / 2);
+        const calc2 = Math.floor(Math.random() * INIT_STOCK_PRICE - INIT_STOCK_PRICE / 2);
+
+        const frunc = Math.abs(calc1) >= Math.abs(calc2) ? calc1 : prevPrice + calc2 <= 0 ? calc1 : calc2;
+        const price = ceilToUnit(prevPrice + frunc, 100);
+        const info = [];
+
+        // 주가 변동 회사일 경우, 플레이어 2명에게 정보 제공
+        if (isChangePrice) {
+          const infoPlayerIdx = randomPlayers.pop();
+          if (infoPlayerIdx !== undefined) {
+            const partnerPlayerIdx = (infoPlayerIdx + stock.round + 1) % players.length;
+            info.push(players[infoPlayerIdx].userId, players[partnerPlayerIdx].userId);
+          }
+        }
+
+        newCompanies[company][round] = {
+          가격: price,
+          정보: info,
+        };
       }
     });
 
+    // 회사 별 주식 재고 설정
     const remainingStocks = {};
     Object.keys(newCompanies).forEach((company) => {
       remainingStocks[company] = players.length * 3;

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -90,13 +90,13 @@ export class StockService {
 
     const companyPriceChange: string[][] = [[]];
     const newCompanies = {} as Record<stock.CompanyNames, CompanyInfo[]>;
-    const playerIdxs = [...Array(players.length).keys()];
+    const playerIdxs = Array.from({ length: players.length }, (_, idx) => idx);
 
     // 플레이어에게 줄 정보의 절반 개수
     const halfInfoCount = Math.min(Math.max(Math.floor(90 / players.length), 1), 3);
 
     // 플레이어에게 줄 정보를 랜덤하게 주기 위한 배열
-    const randomPlayers = [...Array(halfInfoCount).keys()]
+    const randomPlayers = Array.from({ length: halfInfoCount }, (_, idx) => idx)
       .map(() => playerIdxs)
       .flat()
       .sort(() => Math.random() - 0.5);

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -92,7 +92,7 @@ export class StockService {
     const newCompanies = {} as Record<stock.CompanyNames, CompanyInfo[]>;
     const playerIdxs = [...Array(players.length).keys()];
 
-    const halfInfoCount = players.length > 30 ? Math.floor(90 / players.length) : 3;
+    const halfInfoCount = Math.min(Math.max(Math.floor(90 / players.length), 1), 3);
     const randomPlayers = [...Array(halfInfoCount).keys()]
       .map(() => playerIdxs)
       .flat()

--- a/package/shared/config/src/stock.ts
+++ b/package/shared/config/src/stock.ts
@@ -12,9 +12,16 @@ export const COMPANY_NAMES = {
 } as const;
 export type CompanyNames = (typeof COMPANY_NAMES)[keyof typeof COMPANY_NAMES];
 
+/**
+ * 랜덤하게 회사 이름을 선택하여 반환하는 함수
+ * @param {number} [length] - 반환할 회사 이름의 개수. 미지정시 전체 회사 반환. 최대 10까지
+ * @returns {string[]} 선택된 회사 이름 배열
+ */
 export const getRandomCompanyNames = (length?: number): string[] => {
   const names = Object.keys(COMPANY_NAMES).map((key) => key);
   names.sort(() => Math.random() - 0.5);
   const result = names.splice(0, length ?? names.length);
   return result;
 };
+
+export const INIT_STOCK_PRICE = 100000;


### PR DESCRIPTION
주식 게임의 초기화 로직을 개선하고 가독성을 높였습니다.

주요 변경사항:
1. 초기 주식 가격을 상수(INIT_STOCK_PRICE)로 분리
2. 변수명을 더 명확하게 변경 (i → round, isChange → isChangePrice)
3. 라운드별 주가 변동 회사 선정 로직에 제한 추가
   - 라운드당 (플레이어 수의 1/3) 만큼의 회사가 선정
   - 최대 10개로 제한 (전체 회사가 10개이므로)
4. 코드 가독성 개선을 위한 주석 추가
5. getRandomCompanyNames 함수에 JSDoc 문서 추가

이러한 변경으로 코드의 유지보수성과 가독성이 향상되었습니다.

주식게임에서 주식의 가격과 플레이어에게 정보를 초기에 설정하는 가장 핵심적인 로직이예요.
이해되지 않는 부분이 있다면 말씀해주세요! 그 부분은 이해하기 쉽게 로직을 변경해야 하니까요.
혹시나 룰북도 함께 [첨부](https://www.miricanvas.com/v/13tjjix) 하겠습니다