### PR TITLE
chore: yarnrc.yml 파일에 window 운영체제 추가

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -24,5 +24,6 @@ supportedArchitectures:
   os:
     - darwin
     - linux
+    - win32
 
 yarnPath: .yarn/releases/yarn-4.0.2.cjs


### PR DESCRIPTION
## 이슈
윈도우 운영체제에서 server 폴더 아래 yarn turbo:dev 명령어가 실행되지 않는 문제점이 있었음
자세한 내용 스레드: https://discordapp.com/channels/1311649881164611586/1311649881164611592/1318518560393269288

## 해결
yarnrc.yml 파일에 window 운영체제가 포함되지 않았기 때문이었음.
포함하고 다시 명령어 실행하니 해결됨.