### PR TITLE
feat: 게임 페이지 내 새로고침 버튼 추가, 주식사기 버튼 비활성 상태 색 변경

### DIFF
--- a/app/koi-client/src/page/@party@[partyId]/component/MainHeader.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/MainHeader.tsx
@@ -63,7 +63,7 @@ const PartyHeader = () => {
         }
         RightComponent={
           <Space>
-            <Button shape="circle" icon={<ReloadOutlined />} onClick={() => navigate(0)} />
+            <Button shape="circle" icon={<ReloadOutlined />} onClick={() => window.location.reload(true)} />
             <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">
               <Button shape="circle" icon={<EllipsisOutlined />} />
             </Dropdown>

--- a/app/koi-client/src/page/@party@[partyId]/component/MainHeader.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/MainHeader.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { Button, Dropdown, MenuProps, message } from 'antd';
-import { ArrowLeftOutlined, EllipsisOutlined } from '@ant-design/icons';
+import { Button, Dropdown, MenuProps, Space, message } from 'antd';
+import { ArrowLeftOutlined, EllipsisOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useAtomValue } from 'jotai';
 import { css } from '@linaria/core';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -63,9 +62,12 @@ const PartyHeader = () => {
           />
         }
         RightComponent={
-          <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">
-            <Button shape="circle" icon={<EllipsisOutlined />} />
-          </Dropdown>
+          <Space>
+            <Button shape="circle" icon={<ReloadOutlined />} onClick={() => navigate(0)} />
+            <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">
+              <Button shape="circle" icon={<EllipsisOutlined />} />
+            </Dropdown>
+          </Space>
         }
       />
       {contextHolder}

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Buy.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Buy.tsx
@@ -2,6 +2,7 @@ import { objectEntries } from '@toss/utils';
 import { useAtomValue } from 'jotai';
 import { Button, message } from 'antd';
 import { ShoppingCartOutlined } from '@ant-design/icons';
+import styled from '@emotion/styled';
 import { UserStore } from '../../../../../../store';
 import { Query } from '../../../../../../hook';
 import Box from '../../../../../../component-presentation/Box';
@@ -54,7 +55,7 @@ const Buy = ({ stockId }: Props) => {
             key={company}
             value={company}
             rightComponent={
-              <Button
+              <BuyButton
                 name="buy"
                 icon={<ShoppingCartOutlined />}
                 disabled={count === 0 || isDisabled}
@@ -64,7 +65,7 @@ const Buy = ({ stockId }: Props) => {
                 }}
               >
                 사기
-              </Button>
+              </BuyButton>
             }
           />
         );
@@ -74,3 +75,11 @@ const Buy = ({ stockId }: Props) => {
 };
 
 export default Buy;
+
+const BuyButton = styled(Button)`
+  &:disabled {
+    background-color: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.5);
+    border-color: rgba(255, 255, 255, 0.3);
+  }
+`;


### PR DESCRIPTION
### navigate(0)을 사용하여 게임 페이지 내 새로고침 버튼 추가
- 게임 페이지의 우측 상단에 새로고침 버튼을 추가하여 사용자 편의성 개선

https://github.com/user-attachments/assets/5b486543-824e-41a6-8e10-4b5bbfe05b55

### 주식 사기 버튼 비활성화 시 가시성 개선을 위한 색상 변경

- 어두운 배경(#000084)에서도 버튼의 상태를 직관적으로 파악할 수 있도록 색상 개선

| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| 주식 구매 버튼 disable 상태 | <img width="262" alt="스크린샷 2025-01-08 오후 11 02 43" src="https://github.com/user-attachments/assets/cbdb51e4-ebfa-4d18-8de8-30b70c006636" /> | <img width="267" alt="스크린샷 2025-01-08 오후 11 06 37" src="https://github.com/user-attachments/assets/e7664148-0b2b-48e3-8748-23c11a4f08cb" /> |

- 활성화/비활성화 상태 비교

https://github.com/user-attachments/assets/0d20160f-b43a-463f-8963-d55055593599

