### PR TITLE
feat: 알림 한번씩 뜨게끔 하기

### DIFF
--- a/app/koi-client/src/page/@party@[partyId]/component/Poll.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Poll.tsx
@@ -183,6 +183,7 @@ const Poll = () => {
             },
           })
             .then(() => {
+              message.destroy();
               messageApi.open({
                 content: `투표가 완료되었습니다.`,
                 duration: 2,
@@ -190,6 +191,7 @@ const Poll = () => {
               });
             })
             .catch((e: Error) => {
+              message.destroy();
               messageApi.open({
                 content: `${e.message}`,
                 duration: 2,

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Buy.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Buy.tsx
@@ -29,6 +29,7 @@ const Buy = ({ stockId }: Props) => {
   const onClickBuy = (company: string) => {
     buyStock({ amount: 1, company, stockId, unitPrice: companiesPrice[company], userId })
       .then(() => {
+        messageApi.destroy();
         messageApi.open({
           content: '주식을 구매하였습니다.',
           duration: 2,
@@ -36,6 +37,7 @@ const Buy = ({ stockId }: Props) => {
         });
       })
       .catch((reason: Error) => {
+        messageApi.destroy();
         messageApi.open({
           content: `${reason.message}`,
           duration: 2,

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Sell.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Sell.tsx
@@ -28,6 +28,7 @@ const Sell = ({ stockId }: Props) => {
   const onClickSell = (company: string) => {
     sellStock({ amount: 1, company, stockId, unitPrice: companiesPrice[company], userId })
       .then(() => {
+        messageApi.destroy();
         messageApi.open({
           content: '주식을 팔았습니다.',
           duration: 2,
@@ -35,6 +36,7 @@ const Sell = ({ stockId }: Props) => {
         });
       })
       .catch((reason: Error) => {
+        messageApi.destroy();
         messageApi.open({
           content: `${reason.message}`,
           duration: 2,


### PR DESCRIPTION
## antd의 messageApi.destory() 를 사용해 알림 동작 개선

- 알림이 여러개 생성될 시 메인 컨테이너를 가려 조작이 어려워지는 문제 개선
- 알림을 한번씩(하나씩) 뜨게끔 수정

| | 변경 전 | 변경 후 |
|----------|----------|--------|
| 알림<br>동작<br>방식  | ![변경전](https://github.com/user-attachments/assets/ad6a42a8-c945-46f4-9855-9f901bb46b52)  | ![변경후](https://github.com/user-attachments/assets/9fde00ad-1c44-4be6-b4d0-cd624c537601)  |






