### PR TITLE
feat: 주식 정보 랜덤 뽑기

### DIFF
--- a/app/koi-client/src/hook/query/Stock/index.ts
+++ b/app/koi-client/src/hook/query/Stock/index.ts
@@ -17,3 +17,4 @@ export { default as useQueryLog } from './useQueryLog';
 export { default as useAllSellPrice } from './useAllSellPrice';
 export { default as useQueryStockPhase } from './useQueryStockPhase';
 export { default as useRemoveStockSession } from './useRemoveStockSession';
+export { default as useDrawStockInfo } from './useDrawStockInfo';

--- a/app/koi-client/src/hook/query/Stock/useDrawStockInfo.tsx
+++ b/app/koi-client/src/hook/query/Stock/useDrawStockInfo.tsx
@@ -1,0 +1,15 @@
+import { Request, Response } from 'shared~type-stock';
+import { useMutation } from 'lib-react-query';
+import { serverApiUrl } from '../../../config/baseUrl';
+
+const useDrawStockInfo = () => {
+  return useMutation<Request.PostDrawStockInfo, Response.Stock>({
+    api: {
+      hostname: serverApiUrl,
+      method: 'POST',
+      pathname: '/stock/draw-info',
+    },
+  });
+};
+
+export default useDrawStockInfo;

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/DrawInfo.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/DrawInfo.tsx
@@ -52,7 +52,7 @@ const DrawStockInfo = ({ stockId }: Props) => {
     return <>불러오는 중</>;
   }
 
-  const isDisabled = timeIdx === undefined || timeIdx >= 9 || !stock.isTransaction;
+  const isDisabled = timeIdx === undefined || timeIdx >= 7 || !stock.isTransaction;
 
   return (
     <>

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/DrawInfo.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/DrawInfo.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import { Button, Modal, message } from 'antd';
+import { UserStore } from '../../../../../../store';
+import { Query } from '../../../../../../hook';
+
+type Props = {
+  stockId: string;
+};
+
+const DrawStockInfo = ({ stockId }: Props) => {
+  const supabaseSession = useAtomValue(UserStore.supabaseSession);
+  const userId = supabaseSession?.user.id;
+  const [open, setOpen] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const { mutateAsync: drawStockInfo, isLoading } = Query.Stock.useDrawStockInfo();
+  const [messageApi, contextHolder] = message.useMessage();
+  const { data: stock, timeIdx } = Query.Stock.useQueryStock(stockId);
+
+  const onClickDrawStockInfo = () => {
+    if (!userId) return;
+    drawStockInfo({
+      stockId,
+      userId,
+    })
+      .then(() => {
+        messageApi.destroy();
+        messageApi.open({
+          content: '뽑기에 성공하였습니다',
+          duration: 2,
+          type: 'success',
+        });
+        setOpen(false);
+      })
+      .catch((reason: Error) => {
+        messageApi.destroy();
+        messageApi.open({
+          content: `${reason.message}`,
+          duration: 2,
+          type: 'error',
+        });
+      });
+  };
+
+  useEffect(() => {
+    if (open && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [open]);
+
+  if (!stock || !userId) {
+    return <>불러오는 중</>;
+  }
+
+  const isDisabled = timeIdx === undefined || timeIdx >= 9 || !stock.isTransaction;
+
+  return (
+    <>
+      {contextHolder}
+      <Button size="small" onClick={() => setOpen(true)} disabled={isDisabled}>
+        정보 뽑기
+      </Button>
+      <div
+        css={{
+          position: 'absolute',
+        }}
+      >
+        <Modal
+          title="주식 정보 뽑기"
+          open={open}
+          onCancel={() => setOpen(false)}
+          okText="뽑기"
+          cancelText="닫기"
+          getContainer={false}
+          okButtonProps={{ loading: isLoading }}
+          onOk={onClickDrawStockInfo}
+        >
+          <div ref={modalRef} tabIndex={-1}>
+            <p>1회 뽑는 데 30원의 금액이 들어요.</p>
+          </div>
+        </Modal>
+      </div>
+    </>
+  );
+};
+
+export default DrawStockInfo;

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useAtomValue } from 'jotai';
 import { commaizeNumber, objectEntries } from '@toss/utils';
 import { getDateDistance } from '@toss/date';
@@ -17,10 +17,6 @@ import DrawStockInfo from './DrawInfo';
 
 const convertIndexToTime = (idx: number, fluctuationsInterval: number) => {
   return prependZero(idx * fluctuationsInterval, 2);
-};
-
-const convertTimeToIndex = (time: string, fluctuationsInterval: number) => {
-  return Math.floor(parseInt(time, 10) / fluctuationsInterval);
 };
 
 const getSecondsTime = (startTime: string) => {
@@ -49,11 +45,6 @@ const Home = ({ stockId }: Props) => {
   const { user } = Query.Stock.useUser({ stockId, userId });
 
   const { allSellPrice, allUserSellPriceDesc } = Query.Stock.useAllSellPrice({ stockId, userId });
-
-  const currentTimeIndex = useMemo(() => {
-    if (!stock) return 0;
-    return convertTimeToIndex(getMinutesTime(stock.startedTime), stock.fluctuationsInterval);
-  }, [stock]);
 
   if (!user || !stock) {
     return <div>불러오는 중.</div>;
@@ -144,7 +135,7 @@ const Home = ({ stockId }: Props) => {
       <br />
       <Flex align="center" justify="space-between" gap={4} css={{ width: '100%' }}>
         <H3>내가 가진 정보</H3>
-        {currentTimeIndex < 8 && <DrawStockInfo stockId={stockId} />}
+        <DrawStockInfo stockId={stockId} />
       </Flex>
       {myInfos.map(({ company, price, timeIdx }) => {
         return (

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home.tsx
@@ -1,35 +1,15 @@
-import React from 'react';
 import { useAtomValue } from 'jotai';
 import { commaizeNumber, objectEntries } from '@toss/utils';
-import { getDateDistance } from '@toss/date';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
-import dayjs from 'dayjs';
 import { Flex } from 'antd';
 import { UserStore } from '../../../../../../store';
 import { Query } from '../../../../../../hook';
 import Box from '../../../../../../component-presentation/Box';
-import prependZero from '../../../../../../service/prependZero';
-import { colorDown, colorUp } from '../../../../../../config/color';
 import DrawStockInfo from './DrawInfo';
-
-// ================================================================================
-
-const convertIndexToTime = (idx: number, fluctuationsInterval: number) => {
-  return prependZero(idx * fluctuationsInterval, 2);
-};
-
-const getSecondsTime = (startTime: string) => {
-  return prependZero(getDateDistance(dayjs(startTime).toDate(), new Date()).seconds, 2);
-};
-
-const getMinutesTime = (startTime: string) => {
-  return prependZero(getDateDistance(dayjs(startTime).toDate(), new Date()).minutes, 2);
-};
+import MyInfosContent from './MyInfosContent';
+import RunningTimeDisplay from './RunningTimeDisplay';
 
 const getProfitRatio = (v: number) => ((v / 1000000) * 100 - 100).toFixed(2);
-
-// =================================================================================
 
 interface Props {
   stockId: string;
@@ -103,7 +83,7 @@ const Home = ({ stockId }: Props) => {
   return (
     <>
       <H3>홈</H3>
-      <Box title="진행 시간" value={`${getMinutesTime(stock.startedTime)}:${getSecondsTime(stock.startedTime)}`} />
+      <RunningTimeDisplay startTime={stock.startedTime} />
       <Box
         title="잔액"
         value={`${commaizeNumber(user.money)}원`}
@@ -137,25 +117,7 @@ const Home = ({ stockId }: Props) => {
         <H3>내가 가진 정보</H3>
         <DrawStockInfo stockId={stockId} />
       </Flex>
-      {myInfos.map(({ company, price, timeIdx }) => {
-        return (
-          <Box
-            key={`${company}_${timeIdx}`}
-            title={`${company}`}
-            value={`${price >= 0 ? '▲' : '▼'}${commaizeNumber(Math.abs(price))}`}
-            valueColor={price >= 0 ? colorUp : colorDown}
-            rightComponent={
-              <div
-                css={css`
-                  font-size: 18px;
-                `}
-              >
-                {convertIndexToTime(timeIdx, stock.fluctuationsInterval)}:00
-              </div>
-            }
-          />
-        );
-      })}
+      <MyInfosContent myInfos={myInfos} fluctuationsInterval={stock.fluctuationsInterval} />
       <br />
       <H3>추천 대화상대</H3>
       <ul>

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/MyInfosContent.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/MyInfosContent.tsx
@@ -1,0 +1,42 @@
+import { commaizeNumber } from '@toss/utils';
+import { css } from '@emotion/react';
+import prependZero from '../../../../../../service/prependZero';
+import { colorDown, colorUp } from '../../../../../../config/color';
+import Box from '../../../../../../component-presentation/Box';
+
+type Props = {
+  myInfos: {
+    company: string;
+    timeIdx: number;
+    price: number;
+  }[];
+  fluctuationsInterval: number;
+};
+
+const MyInfosContent = ({ myInfos, fluctuationsInterval }: Props) => {
+  return (
+    <>
+      {myInfos.map(({ company, price, timeIdx }) => {
+        return (
+          <Box
+            key={`${company}_${timeIdx}`}
+            title={`${company}`}
+            value={`${price >= 0 ? '▲' : '▼'}${commaizeNumber(Math.abs(price))}`}
+            valueColor={price >= 0 ? colorUp : colorDown}
+            rightComponent={
+              <div
+                css={css`
+                  font-size: 18px;
+                `}
+              >
+                {prependZero(timeIdx * fluctuationsInterval, 2)}:00
+              </div>
+            }
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default MyInfosContent;

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/RunningTimeDisplay.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/RunningTimeDisplay.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { getDateDistance } from '@toss/date';
+import dayjs from 'dayjs';
+import Box from '../../../../../../component-presentation/Box';
+import prependZero from '../../../../../../service/prependZero';
+
+const getSecondsTime = (startTime: string) => {
+  return prependZero(getDateDistance(dayjs(startTime).toDate(), new Date()).seconds, 2);
+};
+
+const getMinutesTime = (startTime: string) => {
+  return prependZero(getDateDistance(dayjs(startTime).toDate(), new Date()).minutes, 2);
+};
+
+const RunningTimeDisplay = ({ startTime }: { startTime: string }) => {
+  const [time, setTime] = useState(() => `${getMinutesTime(startTime)}:${getSecondsTime(startTime)}`);
+
+  useEffect(() => {
+    const updateTime = () => {
+      const newTime = `${getMinutesTime(startTime)}:${getSecondsTime(startTime)}`;
+      setTime(newTime);
+    };
+
+    // 초기 시간 동기화
+    updateTime();
+
+    const timer = setInterval(updateTime, 1000);
+
+    // window focus 이벤트에 대한 처리 // refetchIntervalInBackground 옵션 예외 처리
+    const handleFocus = () => {
+      updateTime();
+    };
+
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [startTime]);
+
+  return <Box title="진행 시간" value={time} />;
+};
+
+RunningTimeDisplay.displayName = 'RunningTimeDisplay';
+
+export default RunningTimeDisplay;

--- a/package/feature/feature-nest-stock/src/sotck.constants.ts
+++ b/package/feature/feature-nest-stock/src/sotck.constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_DRAW_COST = 300_000;
+export const ROUND_SKIP_STEP = 2;

--- a/package/feature/feature-nest-stock/src/stock.controller.ts
+++ b/package/feature/feature-nest-stock/src/stock.controller.ts
@@ -60,6 +60,11 @@ export class StockController {
     return this.stockService.buyStock(body.stockId, body);
   }
 
+  @Post('/draw-info')
+  buyStockInfo(@Body() body: Request.PostDrawStockInfo): Promise<StockSchema> {
+    return this.stockService.drawStockInfo(body.stockId, body);
+  }
+
   @Post('/sell')
   sellStock(@Body() body: Request.PostSellStock): Promise<StockSchema> {
     return this.stockService.sellStock(body.stockId, body);

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -291,7 +291,7 @@ export class StockService {
 
       const nextTimeIdx = timeIdx + 1;
 
-      const DEFAULT_DRAW_COST = 1;
+      const DEFAULT_DRAW_COST = 300_000;
 
       if (user.money < DEFAULT_DRAW_COST) {
         throw new HttpException('잔액이 부족합니다', HttpStatus.CONFLICT);

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -288,10 +288,10 @@ export class StockService {
         Math.floor(getDateDistance(stock.startedTime, new Date()).minutes / stock.fluctuationsInterval),
         9,
       );
-
-      const nextTimeIdx = timeIdx + 1;
-
       const DEFAULT_DRAW_COST = 300_000;
+      const ROUND_SKIP_STEP = 2;
+
+      const nextTimeIdx = timeIdx + ROUND_SKIP_STEP;
 
       if (user.money < DEFAULT_DRAW_COST) {
         throw new HttpException('잔액이 부족합니다', HttpStatus.CONFLICT);

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -15,6 +15,7 @@ import { ResultService } from './result/result.service';
 import { Result } from './result/result.schema';
 import { StockRepository } from './stock.repository';
 import { UserRepository } from './user/user.repository';
+import { DEFAULT_DRAW_COST, ROUND_SKIP_STEP } from './sotck.constants';
 
 @Injectable()
 export class StockService {
@@ -288,8 +289,6 @@ export class StockService {
         Math.floor(getDateDistance(stock.startedTime, new Date()).minutes / stock.fluctuationsInterval),
         9,
       );
-      const DEFAULT_DRAW_COST = 300_000;
-      const ROUND_SKIP_STEP = 2;
 
       const nextTimeIdx = timeIdx + ROUND_SKIP_STEP;
 

--- a/package/feature/feature-nest-stock/src/stock.service.ts
+++ b/package/feature/feature-nest-stock/src/stock.service.ts
@@ -314,11 +314,22 @@ export class StockService {
       const randomIndex = Math.floor(Math.random() * availableCompanies.length);
       const selectedCompany = availableCompanies[randomIndex];
 
-      // 랜덤으로 시점 선택
-      const randomTimeIndex = Math.floor(Math.random() * companies.get(selectedCompany).length);
+      // 랜덤으로 시점 선택 (정보를 가지고 있는 시점만 선택)
+      let randomTimeIndex =
+        Math.floor(Math.random() * (companies.get(selectedCompany).length - nextTimeIdx)) + nextTimeIdx;
 
       // 선택된 회사의 정보 업데이트
       const companyInfos = [...companies.get(selectedCompany)]; // 배열 복사
+
+      // 해당 배열안에 이미 user Id가 있는지 확인
+      let isExistUser = companyInfos[randomTimeIndex].정보.find((v) => v === userId);
+      // user Id가 있는 때는 randomTimeIndex를 다시 생성
+      while (isExistUser) {
+        randomTimeIndex =
+          Math.floor(Math.random() * (companies.get(selectedCompany).length - nextTimeIdx)) + nextTimeIdx;
+        isExistUser = companyInfos[randomTimeIndex].정보.find((v) => v === userId);
+      }
+
       companyInfos[randomTimeIndex] = {
         ...companyInfos[randomTimeIndex],
         정보: [...companyInfos[randomTimeIndex].정보, userId],

--- a/package/shared/type-stock/Request.ts
+++ b/package/shared/type-stock/Request.ts
@@ -16,6 +16,11 @@ export type PostBuyStock = {
   unitPrice: number;
 };
 
+export type PostDrawStockInfo = {
+  stockId: string;
+  userId: string;
+};
+
 export type PostSellStock = {
   stockId: string;
   userId: string;


### PR DESCRIPTION
# 🎲 주식 정보 랜덤 뽑기 기능 추가

## 📝 작업 개요
- 미래 라운드의 주식 정보를 랜덤으로 뽑을 수 있는 기능 구현
- 유저당 중복되지 않는 뽑기 정보 제공
- 뽑기 비용: 30만원

## 🛠 구현 상세
### Frontend
- [x] 랜덤 뽑기 UI 구현
- [x] 뽑기 결과 표시 모달
- [x] 보유 금액 검증 로직
- [x] 7라운드 이후 뽑기 버튼 비활성화
- [x] 진행 시간 실시간 반영 로직

### Backend
- [x] 랜덤 주식 정보 조회 API
- [x] 중복 방지 로직
- [x] 사용자별 뽑기 이력 관리
- [x] 비용 차감 처리
- [x] +2 라운드의 정보부터 뽑기 가능

## 🤔 검토 필요 사항
1. 데이터베이스 설계
   - [ ] 사용자별 뽑기 이력 테이블 추가 필요성
   - [ ] 기존 테이블 스키마 변경 여부

2. UX 관련
   - [ ] 별도의 '내가 뽑은 정보' 뷰 구현 여부
3. 로직 관련
  - 그럼에도 1초를 남기는 시점에 오류를 띄워줘야 하는지? 

## 📋 관련 문서
- [초기 정보 뽑기 Figjam flow](https://www.figma.com/board/ef6bwIYy5IJ9gQvYB9DerI/%EC%A0%95%EB%B3%B4-%EB%BD%91%EA%B8%B0?node-id=0-1&t=dX9sc5mE5bm8hQhj-1)


## 시나리오
![draw-flow](https://github.com/user-attachments/assets/a02beb79-0b91-4911-aa06-a8b1ef6c9924)

