### PR TITLE
feat: 스톡(Stock) 기능 사용자 등록 API 개선 및 트랜잭션 처리 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     'import/no-unresolved': 0,
     'import/prefer-default-export': 0,
     'max-classes-per-file': 0,
+    'new-cap': 0,
     'no-alert': 0,
     'no-await-in-loop': 0,
     'no-console': 0,

--- a/app/koi-client/src/hook/query/Stock/index.ts
+++ b/app/koi-client/src/hook/query/Stock/index.ts
@@ -20,4 +20,4 @@ export { default as useRemoveStockSession } from './useRemoveStockSession';
 export { default as useDrawStockInfo } from './useDrawStockInfo';
 export { default as useStartLoan } from './useStartLoan';
 export { default as useSetPhase } from './useSetPhase';
-export { default as useCreateUser } from './useCreateUser';
+export { default as useRegisterUser } from './useRegisterUser';

--- a/app/koi-client/src/hook/query/Stock/index.ts
+++ b/app/koi-client/src/hook/query/Stock/index.ts
@@ -20,3 +20,4 @@ export { default as useRemoveStockSession } from './useRemoveStockSession';
 export { default as useDrawStockInfo } from './useDrawStockInfo';
 export { default as useStartLoan } from './useStartLoan';
 export { default as useSetPhase } from './useSetPhase';
+export { default as useCreateUser } from './useCreateUser';

--- a/app/koi-client/src/hook/query/Stock/useCreateUser.tsx
+++ b/app/koi-client/src/hook/query/Stock/useCreateUser.tsx
@@ -1,0 +1,15 @@
+import { useMutation } from 'lib-react-query';
+import { Request, Response } from 'shared~type-stock';
+import { serverApiUrl } from '../../../config/baseUrl';
+
+const useCreateUser = () => {
+  return useMutation<Request.PostCreateUser, Response.GetCreateUser>({
+    api: {
+      hostname: serverApiUrl,
+      method: 'POST',
+      pathname: '/stock/user',
+    },
+  });
+};
+
+export default useCreateUser;

--- a/app/koi-client/src/hook/query/Stock/useRegisterUser.tsx
+++ b/app/koi-client/src/hook/query/Stock/useRegisterUser.tsx
@@ -2,14 +2,14 @@ import { useMutation } from 'lib-react-query';
 import { Request, Response } from 'shared~type-stock';
 import { serverApiUrl } from '../../../config/baseUrl';
 
-const useCreateUser = () => {
+const useRegisterUser = () => {
   return useMutation<Request.PostCreateUser, Response.GetCreateUser>({
     api: {
       hostname: serverApiUrl,
       method: 'POST',
-      pathname: '/stock/user',
+      pathname: '/stock/user/register',
     },
   });
 };
 
-export default useCreateUser;
+export default useRegisterUser;

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/ProfileSetter.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/ProfileSetter.tsx
@@ -11,7 +11,7 @@ const ProfileSetter = ({ stockId }: Props) => {
   const supabaseSession = useAtomValue(UserStore.supabaseSession);
 
   const { data: user } = Query.Supabase.useMyProfile({ supabaseSession });
-  const { mutateAsync } = Query.Stock.useCreateUser();
+  const { mutateAsync } = Query.Stock.useRegisterUser();
 
   const userId = user?.data?.id;
   const gender = user?.data?.gender;

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/ProfileSetter.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/ProfileSetter.tsx
@@ -11,25 +11,24 @@ const ProfileSetter = ({ stockId }: Props) => {
   const supabaseSession = useAtomValue(UserStore.supabaseSession);
 
   const { data: user } = Query.Supabase.useMyProfile({ supabaseSession });
-  const { mutateAsync } = Query.Stock.useSetUser();
+  const { mutateAsync } = Query.Stock.useCreateUser();
 
   const userId = user?.data?.id;
+  const gender = user?.data?.gender;
+  const nickname = user?.data?.username;
 
   useEffect(() => {
+    if (!userId || !gender || !nickname) return;
+
     mutateAsync({
-      index: 0,
-      inventory: {},
-      lastActivityTime: new Date(),
-      loanCount: 0,
-      money: 1000000,
       stockId,
       userId,
       userInfo: {
-        gender: user?.data?.gender,
-        nickname: user?.data?.username,
+        gender,
+        nickname,
       },
     });
-  }, [mutateAsync, stockId, user?.data?.gender, user?.data?.username, userId]);
+  }, [gender, mutateAsync, nickname, stockId, userId]);
 
   return <></>;
 };

--- a/package/feature/feature-nest-stock/src/user/user.controller.ts
+++ b/package/feature/feature-nest-stock/src/user/user.controller.ts
@@ -18,6 +18,11 @@ export class UserController {
     return this.userService.setUser(body);
   }
 
+  @Post('/register')
+  async registerUser(@Body() body: StockUser): Promise<Response.GetCreateUser> {
+    return this.userService.registerUser(body);
+  }
+
   @Post('/introduce')
   async setIntroduce(@Body() body: Request.PostIntroduce): Promise<Response.SetIntroduce> {
     return this.userService.setIntroduce(body.stockId, body.userId, body.introduction);

--- a/package/feature/feature-nest-stock/src/user/user.controller.ts
+++ b/package/feature/feature-nest-stock/src/user/user.controller.ts
@@ -14,7 +14,7 @@ export class UserController {
   }
 
   @Post()
-  setUser(@Body() body: StockUser): Promise<StockUser> {
+  setUser(@Body() body: StockUser): Promise<boolean> {
     return this.userService.setUser(body);
   }
 

--- a/package/feature/feature-nest-stock/src/user/user.repository.ts
+++ b/package/feature/feature-nest-stock/src/user/user.repository.ts
@@ -82,6 +82,14 @@ export class UserRepository {
     return !!(await this.userModel.deleteMany(filter, options));
   }
 
+  async updateOne(
+    filter: FilterQuery<StockUser>,
+    update: UpdateQuery<StockUser>,
+    options?: UpdateOptions & Omit<MongooseQueryOptions<StockUser>, 'lean'>,
+  ): Promise<boolean> {
+    return !!(await this.userModel.updateOne(filter, update, options));
+  }
+
   async updateMany(
     filter: FilterQuery<StockUser>,
     update: UpdateQuery<StockUser>,

--- a/package/feature/feature-nest-stock/src/user/user.schema.ts
+++ b/package/feature/feature-nest-stock/src/user/user.schema.ts
@@ -1,6 +1,7 @@
 import { StockUserForm, StockUserRequired, StockUserSchema, StockUserInfoSchema } from 'shared~type-stock';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, SchemaTypes } from 'mongoose';
+import { StockConfig } from 'shared~config';
 
 @Schema({ _id: false })
 export class StockUserInfo implements StockUserInfoSchema {
@@ -11,7 +12,7 @@ export class StockUserInfo implements StockUserInfoSchema {
   nickname: string;
 
   @Prop()
-  introduction: string;
+  introduction?: string;
 }
 
 @Schema()
@@ -23,7 +24,7 @@ export class StockUser implements StockUserSchema {
   userId: string;
 
   @Prop({ type: StockUserInfo })
-  userInfo: StockUserInfo;
+  userInfo: StockUserInfoSchema;
 
   @Prop()
   index: number;
@@ -43,8 +44,10 @@ export class StockUser implements StockUserSchema {
   constructor(required: Pick<StockUserSchema, StockUserRequired>, partial: StockUserForm) {
     this.userId = required.userId;
     this.stockId = required.stockId;
+    this.userInfo = required.userInfo;
 
-    this.money = partial.money ?? 1000000;
+    this.index = partial.index ?? 0;
+    this.money = partial.money ?? StockConfig.INIT_STOCK_PRICE;
     this.inventory = partial.inventory ?? {};
     this.lastActivityTime = new Date();
     this.loanCount = partial.loanCount ?? 0;

--- a/package/feature/feature-nest-stock/src/user/user.schema.ts
+++ b/package/feature/feature-nest-stock/src/user/user.schema.ts
@@ -47,7 +47,7 @@ export class StockUser implements StockUserSchema {
     this.userInfo = required.userInfo;
 
     this.index = partial.index ?? 0;
-    this.money = partial.money ?? StockConfig.INIT_STOCK_PRICE;
+    this.money = partial.money ?? StockConfig.INIT_USER_MONEY;
     this.inventory = partial.inventory ?? {};
     this.lastActivityTime = new Date();
     this.loanCount = partial.loanCount ?? 0;

--- a/package/feature/feature-nest-stock/src/user/user.service.ts
+++ b/package/feature/feature-nest-stock/src/user/user.service.ts
@@ -42,8 +42,8 @@ export class UserService {
     return this.userRepository.findOne({ stockId, userId }, null, options);
   }
 
-  setUser(user: StockUser): Promise<StockUser> {
-    return this.userRepository.findOneAndUpdate({ stockId: user.stockId, userId: user.userId }, user, { upsert: true });
+  setUser(user: StockUser): Promise<boolean> {
+    return this.userRepository.updateOne({ stockId: user.stockId, userId: user.userId }, user);
   }
 
   async registerUser(user: StockUser): Promise<Response.GetCreateUser> {

--- a/package/feature/feature-nest-stock/src/user/user.service.ts
+++ b/package/feature/feature-nest-stock/src/user/user.service.ts
@@ -46,6 +46,10 @@ export class UserService {
     return this.userRepository.findOneAndUpdate({ stockId: user.stockId, userId: user.userId }, user, { upsert: true });
   }
 
+  async registerUser(user: StockUser): Promise<Response.GetCreateUser> {
+    return this.userRepository.create(user);
+  }
+
   async alignIndex(stockId: string): Promise<void> {
     // 해당 주식방의 모든 사용자 목록을 가져옵니다
     const allUsers = await this.getUserList(stockId);

--- a/package/shared/config/src/stock.ts
+++ b/package/shared/config/src/stock.ts
@@ -25,6 +25,7 @@ export const getRandomCompanyNames = (length?: number): string[] => {
 };
 
 export const INIT_STOCK_PRICE = 100000;
+export const INIT_USER_MONEY = 1_000_000;
 
 export const LOAN_PRICE = 1_000_000;
 export const BOUNDARY_LOAN_PRICE = 1_000_000;

--- a/package/shared/type-stock/Request.ts
+++ b/package/shared/type-stock/Request.ts
@@ -1,5 +1,5 @@
 import type { ProjectionType, QueryOptions } from 'mongoose';
-import type { StockPhase, StockSchema, StockSchemaWithId } from '.';
+import type { StockPhase, StockSchema, StockSchemaWithId, StockUserRequired, StockUserSchema } from '.';
 
 export type GetStock = {
   stockId: string;
@@ -56,3 +56,6 @@ export type PostSetStockPhase = {
   stockId: string;
   phase: StockPhase;
 };
+
+export type PostCreateUser = Pick<StockUserSchema, StockUserRequired> &
+  Omit<Partial<StockUserSchema>, StockUserRequired>;

--- a/package/shared/type-stock/Response.ts
+++ b/package/shared/type-stock/Response.ts
@@ -33,3 +33,8 @@ export type Common = {
 };
 
 export type SetIntroduce = StockUserSchema;
+
+export type GetCreateUser = {
+  isAlreadyExists: boolean;
+  user: StockUserSchema;
+};


### PR DESCRIPTION
## PR 의도

- [stock.user DB에 동일한 유저 2명 이상이 들어갈 수 있는 문제](https://discord.com/channels/1311649881164611586/1335130698025271319/1346161663572836414)를 발견했습니다. 이를 해결하기 위해 PR을 올립니다.

## 변경 내용

### 1. 사용자 등록(Register) 기능 개선
- 트랜잭션을 활용한 안전한 사용자 생성 로직 구현
- 사용자 중복 등록 방지 및 이미 존재하는 사용자 확인 기능 추가 (`isAlreadyExists` 플래그)
- 새로운 `/stock/user/register` 엔드포인트 추가
- 기존 `setUser`와 구분되는 명확한 사용자 등록 절차 마련

### 2. 코드 품질 개선
- 하드코딩된 초기값들을 config 모듈로 이동 (`INIT_USER_MONEY` 상수 추가)
- 사용자 데이터 생성 시 기본값 처리 로직 개선
- 코드 일관성 강화 및 유지보수성 향상

### 3. 타입 시스템 강화
- `StockUser` 스키마에서 `introduction` 필드를 옵션으로 변경
- 새로운 응답 타입 `Response.GetCreateUser` 추가 (사용자 생성 결과 + 기존 사용자 존재 여부)
- 요청 타입 `Request.PostCreateUser` 추가

### 4. 클라이언트 코드 업데이트
- `useRegisterUser` 훅 추가 및 내보내기
- `ProfileSetter` 컴포넌트에서 새로운 API 호출 방식 적용
