### PR TITLE
Feat: 프로필/투표/파티리스트/백오피스 스크린 UI 개선

### DIFF
--- a/app/koi-client/index.html
+++ b/app/koi-client/index.html
@@ -27,6 +27,10 @@
 
         color: #101010;
         /* text-shadow: 2px 2px #8461f8; */
+
+        /* 폰트 렌더링 최적화 - 피그마와 브라우저 간 일관된 표시를 위한 설정 추가 */
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
 
       html {

--- a/app/koi-client/src/component-presentation/Card.tsx
+++ b/app/koi-client/src/component-presentation/Card.tsx
@@ -48,7 +48,6 @@ const ContainerTitle = styled.div`
 
 const ContainerBolder = styled.div`
   font-size: 24px;
-  font-weight: bolder;
   line-height: 22px;
 `;
 

--- a/app/koi-client/src/component-presentation/Header.tsx
+++ b/app/koi-client/src/component-presentation/Header.tsx
@@ -79,6 +79,7 @@ const CenterSection = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  white-space: nowrap;
 `;
 
 const RightSection = styled.div`

--- a/app/koi-client/src/component-presentation/Header.tsx
+++ b/app/koi-client/src/component-presentation/Header.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@linaria/react';
 import { Avatar } from 'antd';
-import { UserOutlined } from '@ant-design/icons';
+import { UserRound } from 'lucide-react';
 import React from 'react';
 
 interface AvatarProp {
@@ -16,33 +16,47 @@ type Props = {
   | {
       avatar?: AvatarProp;
       LeftComponent?: never;
+      CenterComponent?: never;
     }
   | {
       avatar?: never;
       LeftComponent?: React.ReactNode;
+      CenterComponent?: never;
+    }
+  | {
+      avatar?: AvatarProp;
+      LeftComponent?: never;
+      CenterComponent?: React.ReactNode;
     }
 );
 
-const Header = ({ title, avatar = { isVisible: false }, LeftComponent, RightComponent }: Props) => {
+const Header = ({ title, avatar = { isVisible: false }, CenterComponent, LeftComponent, RightComponent }: Props) => {
   const { isVisible, src, onClick } = avatar;
 
   return (
     <Container>
       <LeftSection>
-        <AvatarWrapper>
-          {LeftComponent || (
-            <Avatar
-              size="large"
-              style={{ cursor: onClick ? 'pointer' : 'default', visibility: isVisible ? 'visible' : 'hidden' }}
-              icon={<UserOutlined />}
-              src={src}
-              onClick={onClick}
-            />
-          )}
-        </AvatarWrapper>
+        {LeftComponent || (
+          <Avatar
+            size="large"
+            style={{
+              alignItems: 'center',
+              backgroundColor: '#4B5563',
+              color: '#D1D5DB',
+              cursor: onClick ? 'pointer' : 'default',
+              display: 'flex',
+              justifyContent: 'center',
+              visibility: isVisible ? 'visible' : 'hidden',
+            }}
+            icon={<UserRound />}
+            src={src}
+            onClick={onClick}
+          />
+        )}
         <Title>{title}</Title>
       </LeftSection>
-      <RIghtSection>{RightComponent}</RIghtSection>
+      {CenterComponent && <CenterSection>{CenterComponent}</CenterSection>}
+      <RightSection>{RightComponent}</RightSection>
     </Container>
   );
 };
@@ -54,27 +68,33 @@ const Title = styled.div`
 `;
 
 const LeftSection = styled.div`
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 4px;
 `;
 
-const RIghtSection = styled.div`
-  flex: 80px;
+const CenterSection = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const RightSection = styled.div`
+  flex: 1;
   display: flex;
   justify-content: flex-end;
 `;
 
 const Container = styled.div`
   position: relative;
-  padding: 24px 12px;
+  padding: 16px 16px;
   box-sizing: border-box;
   display: flex;
   align-items: center;
-`;
-
-const AvatarWrapper = styled.div`
-  flex: 80px;
+  justify-content: space-between;
+  color: white;
 `;
 
 export default Header;

--- a/app/koi-client/src/component-presentation/MobileLayout.tsx
+++ b/app/koi-client/src/component-presentation/MobileLayout.tsx
@@ -18,7 +18,7 @@ const MobileLayout = ({
   HeaderComponent,
   justifyContent = 'center',
   padding = '20px',
-  backgroundColor = '#f1f1f1',
+  backgroundColor = '',
   ScrollViewComponent = ScrollView,
 }: Props) => {
   const isDesktop = useMediaQuery({ query: `(min-width: 800px)` });

--- a/app/koi-client/src/page/@/component/MainHeader.tsx
+++ b/app/koi-client/src/page/@/component/MainHeader.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
+import styled from '@emotion/styled';
 import { Query } from '../../../hook';
 import { UserStore } from '../../../store';
 import Header from '../../../component-presentation/Header';
@@ -24,9 +24,14 @@ const MainHeader = () => {
           },
           src: data,
         }}
+        CenterComponent={<Title>소셜데브클럽</Title>}
       />
     </ProfileValidator>
   );
 };
+const Title = styled.div`
+  color: white;
+  font-size: 20px;
+`;
 
 export default MainHeader;

--- a/app/koi-client/src/page/@/component/PartyList.tsx
+++ b/app/koi-client/src/page/@/component/PartyList.tsx
@@ -1,6 +1,7 @@
-import { Button, Card } from 'antd';
 import { useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
+import { Gamepad2, Users } from 'lucide-react';
+import styled from '@emotion/styled';
 import { UserStore } from '../../../store';
 import { Query } from '../../../hook';
 
@@ -19,9 +20,15 @@ const PartyList = () => {
   return partyList.map((party) => {
     return (
       party.activityId !== 'CLOSE' && (
-        <Card key={party._id} title={party.title}>
-          <Button
-            type="primary"
+        <PartyCard key={party._id}>
+          <PartyInformation>
+            <PartyTitle>{party.title}</PartyTitle>
+            <ParticipantCount>
+              <Users style={{ height: '16px', width: '16px' }} />
+              {party.joinedUserIds.length}/{party.limitAllCount}
+            </ParticipantCount>
+          </PartyInformation>
+          <ParticipateButton
             data-id={party._id}
             onClick={async () => {
               await joinParty({ partyId: party._id, userId: supabaseSession.user.id });
@@ -29,12 +36,60 @@ const PartyList = () => {
             }}
             // disabled={party.publicScope !== 'PUBLIC'}
           >
-            참가
-          </Button>
-        </Card>
+            참가하기
+            <Gamepad2 />
+          </ParticipateButton>
+        </PartyCard>
       )
     );
   });
 };
 
 export default PartyList;
+
+const PartyCard = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  background-color: #252836;
+  padding: 20px 24px;
+  border-radius: 4px;
+`;
+const PartyInformation = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  row-gap: 12px;
+  overflow: hidden;
+`;
+const PartyTitle = styled.h2`
+  color: white;
+  font-size: 20px;
+  margin: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
+`;
+const ParticipantCount = styled.div`
+  display: flex;
+  align-items: center;
+  column-gap: 4px;
+  font-size: 20px;
+  color: rgba(255, 255, 255, 0.6);
+`;
+
+const ParticipateButton = styled.button`
+  flex-shrink: 0;
+  font-family: DungGeunMo;
+  display: flex;
+  align-items: center;
+  column-gap: 8px;
+  padding: 8px;
+  background-color: transparent;
+  border-radius: 4px;
+  border: 1px solid #b6c3fd;
+  color: #b6c3fd;
+  font-size: 14px;
+  cursor: pointer;
+`;

--- a/app/koi-client/src/page/@backoffice@screen@[partyId]/component/StockScreen/Table.tsx
+++ b/app/koi-client/src/page/@backoffice@screen@[partyId]/component/StockScreen/Table.tsx
@@ -21,6 +21,18 @@ const Table = ({ stockId }: Props) => {
 
   return (
     <Wrapper>
+      <Row>
+        <RowHeaderItem>주식이름</RowHeaderItem>
+        <RowHeaderItem>현재 가격</RowHeaderItem>
+        <RowHeaderItem>변동 정보</RowHeaderItem>
+        <RowHeaderItem>남은 수량</RowHeaderItem>
+      </Row>
+      <Row>
+        <RowHeaderItem>주식이름</RowHeaderItem>
+        <RowHeaderItem>현재 가격</RowHeaderItem>
+        <RowHeaderItem>변동 정보</RowHeaderItem>
+        <RowHeaderItem>남은 수량</RowHeaderItem>
+      </Row>
       {companyNames.map((company) => {
         if (timeIdx > 9) {
           return <></>;
@@ -29,8 +41,8 @@ const Table = ({ stockId }: Props) => {
         const remainingStock = stock.remainingStocks[company];
         const diff = timeIdx === 0 ? 0 : companies[company][timeIdx].가격 - companies[company][timeIdx - 1].가격;
         const 등락 =
-          diff > 0 ? `▲${commaizeNumber(Math.abs(diff))}` : diff < 0 ? `▼${commaizeNumber(Math.abs(diff))}` : '';
-        const color = diff > 0 ? '#00ff00' : diff < 0 ? '#ff0000' : undefined;
+          diff > 0 ? `▲${commaizeNumber(Math.abs(diff))}` : diff < 0 ? `▼${commaizeNumber(Math.abs(diff))}` : '-';
+        const color = diff > 0 ? '#60A5FA' : diff < 0 ? '#F87171' : undefined;
 
         return (
           <Row key={company}>
@@ -52,28 +64,43 @@ const Table = ({ stockId }: Props) => {
 };
 
 const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
   width: 100%;
   height: 100%;
+
+  display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
 `;
 
 const Row = styled.div`
   display: flex;
+  align-items: center;
   flex-direction: row;
   width: 50%;
   font-size: 28px;
   color: white;
-  justify-content: space-evenly;
 `;
 
 const RowItem = styled.div<{ color?: CSSProperties['color'] }>`
-  width: 140px;
+  flex: 1;
   ${({ color }) => css`
     color: ${color};
   `};
+  display: flex;
+  justify-content: center;
+`;
+
+const RowHeaderItem = styled.div`
+  flex: 1;
+  color: rgb(202, 202, 202);
+  display: flex;
+  font-size: 20px;
+  justify-content: center;
+  text-decoration: underline;
+  text-underline-offset: 6px;
+  text-decoration-thickness: 1px;
 `;
 
 export default Table;

--- a/app/koi-client/src/page/@backoffice@screen@[partyId]/component/StockScreen/index.tsx
+++ b/app/koi-client/src/page/@backoffice@screen@[partyId]/component/StockScreen/index.tsx
@@ -79,31 +79,37 @@ const Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
+
   width: 100%;
   height: 100%;
+
   padding: 180px 120px;
   box-sizing: border-box;
+  background: linear-gradient(to bottom, #111827, #000000);
 `;
 
 const TimeBox = styled.div`
   position: absolute;
-  display: flex;
-  justify-content: center;
+  text-align: center;
   width: 100%;
-  margin-top: 100px;
-  font-size: 48px;
-  text-shadow: 2px 2px #8461f8;
+  top: 100px;
+
+  font-size: 52px;
   color: white;
+  z-index: 1;
 `;
 
 const Container = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+
   width: 100%;
   height: 100%;
 
-  box-shadow: 5px 5px #000000;
-  background-color: #000084;
+  border-radius: 4px;
+  box-shadow: 5px 5px 10px #000000;
+  background-color: #252836;
+
+  padding: 20px 0;
 `;

--- a/app/koi-client/src/page/@party@[partyId]/component/Poll.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Poll.tsx
@@ -42,7 +42,7 @@ const Poll = () => {
       {contextHolder}
       <List
         itemLayout="horizontal"
-        header={<span>{poll.title}</span>}
+        header={<span style={{ color: '#ffffff', fontSize: '24px' }}>{poll.title}</span>}
         dataSource={poll.votes}
         renderItem={(vote) => {
           const selectedVote = selectedVoteList.find((selectedVote) => selectedVote.title === vote.title);
@@ -109,7 +109,7 @@ const Poll = () => {
                   disabled={countAll === 0}
                   key={vote.title}
                 >
-                  <span>
+                  <span style={{ color: 'white' }}>
                     {countAll}명 <CaretDownFilled />
                   </span>
                 </Dropdown>,
@@ -155,8 +155,8 @@ const Poll = () => {
                     />
                   )
                 }
-                title={vote.title}
-                description={<Progress percent={ratio * 100} showInfo={false} />}
+                title={<span style={{ color: 'white' }}>{vote.title}</span>}
+                description={<Progress trailColor="#2f2f2f" percent={ratio * 100} showInfo={false} />}
               />
             </List.Item>
           );

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home/Home.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home/Home.tsx
@@ -91,7 +91,7 @@ const Home = ({ stockId }: Props) => {
         />
         <br />
         <Flex align="center" justify="space-between" gap={4} css={{ width: '100%' }}>
-          <H3>내가 가진 정보</H3>
+          <h3>내가 가진 정보</h3>
           <DrawStockInfo stockId={stockId} />
         </Flex>
       </Container>
@@ -110,10 +110,6 @@ const Container = styled.div`
   gap: 12px;
   padding: 12px 0 100px 0;
   flex: 1 1 0;
-`;
-
-const H3 = styled.h3`
-  text-shadow: 2px 2px #8461f8;
 `;
 
 // TODO: 만약 영역이 겹치는 이슈가 발생 시 수정

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home/MyLevel.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/Home/MyLevel.tsx
@@ -181,7 +181,6 @@ const NextLevel = styled.div`
 
 const PercentValue = styled.div`
   font-size: 30px;
-  font-weight: 700;
   color: ${COLOR.pastelGreen};
 `;
 

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/StartLoan.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/StartLoan.tsx
@@ -61,7 +61,7 @@ const StartLoan = ({ stockId }: Props) => {
   return (
     <>
       {contextHolder}
-      <LoanButton onClick={() => setOpen(true)} disabled>
+      <LoanButton onClick={() => setOpen(true)} disabled={isDisabled}>
         대출하기
       </LoanButton>
       <div

--- a/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/StartLoan.tsx
+++ b/app/koi-client/src/page/@party@[partyId]/component/Stock/component/Stock/StartLoan.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import { Button, Modal, message } from 'antd';
+import { Modal, message } from 'antd';
 import styled from '@emotion/styled';
 import { UserStore } from '../../../../../../store';
 import { Query } from '../../../../../../hook';
@@ -61,7 +61,7 @@ const StartLoan = ({ stockId }: Props) => {
   return (
     <>
       {contextHolder}
-      <LoanButton onClick={() => setOpen(true)} disabled={isDisabled}>
+      <LoanButton onClick={() => setOpen(true)} disabled>
         대출하기
       </LoanButton>
       <div
@@ -90,8 +90,9 @@ const StartLoan = ({ stockId }: Props) => {
   );
 };
 
-const LoanButton = styled(Button)`
+const LoanButton = styled.button`
   width: 100%;
+  font-family: 'DungGeunMo';
   padding: 16px;
   height: 56px;
   border-radius: 4px;
@@ -101,6 +102,10 @@ const LoanButton = styled(Button)`
   border: none;
   &:hover > span {
     color: white;
+  }
+  &:disabled {
+    opacity: 50%;
+    cursor: not-allowed;
   }
 `;
 

--- a/app/koi-client/src/page/@profile/component/ProfileHeader.tsx
+++ b/app/koi-client/src/page/@profile/component/ProfileHeader.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { ArrowLeftOutlined } from '@ant-design/icons';
 import { css } from '@linaria/core';
 import { useNavigate } from 'react-router-dom';
+import { ChevronLeft } from 'lucide-react';
 import Header from '../../../component-presentation/Header';
 
 const ProfileHeader = () => {
@@ -11,8 +10,8 @@ const ProfileHeader = () => {
     <Header
       title="프로필"
       LeftComponent={
-        <ArrowLeftOutlined
-          size={60}
+        <ChevronLeft
+          size={32}
           onClick={() => {
             navigate(-1);
           }}

--- a/app/koi-client/src/page/@profile/index.tsx
+++ b/app/koi-client/src/page/@profile/index.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
 import { Button, Form, Input, Radio } from 'antd';
 import { useNavigate } from 'react-router-dom';
+import styled from '@emotion/styled';
 import { UserStore } from '../../store';
 import { Query } from '../../hook';
 import AvatarSetter from './component/AvatarSetter';
@@ -75,15 +76,19 @@ export default function Profile() {
           hasFeedback={isDuplicatedUsername}
           validateStatus={isDuplicatedUsername ? 'error' : undefined}
           help={isDuplicatedUsername ? '이미 사용중인 닉네임입니다' : undefined}
-          label="닉네임"
+          label={<Label>닉네임</Label>}
         >
           <Input type="text" name="nickname" required value={username} onChange={(e) => setUsername(e.target.value)} />
         </Form.Item>
 
-        <Form.Item required label="성별">
+        <Form.Item required label={<Label>성별</Label>}>
           <Radio.Group value={gender} onChange={(e) => setGender(e.target.value)}>
-            <Radio value="M">남성</Radio>
-            <Radio value="F">여성</Radio>
+            <Radio value="M">
+              <Label>남성</Label>
+            </Radio>
+            <Radio value="F">
+              <Label>여성</Label>
+            </Radio>
           </Radio.Group>
         </Form.Item>
 
@@ -116,3 +121,8 @@ export default function Profile() {
     </MobileLayout>
   );
 }
+
+// Form.Item의 라벨은 style={{color: 색상}}으로 폰트색이 바뀌지 않아서 span 태그로 대체해서 사용
+const Label = styled.span`
+  color: white;
+`;


### PR DESCRIPTION


## UI 변경 내용

### 메인 페이지
- 상단에 "소셜데브클럽" 문구 추가하며, Header 컴포넌트에 CenterComponent Props 추가했습니다.
  - LeftComponent와 동시에 사용 시 레이아웃 충돌 방지를 위해 타입 제어 추가 (Props 타입 관리)
  - 헤더 내부 레이아웃 및 여백 조정 (padding 24px → 16px)

### 파티리스트
  - "참가중인 인원 / 최대 참여 가능 인원" 정보 표시 추가 (Users 아이콘과 함께 표시)

<img width="200" alt="KakaoTalk_Photo_2025-03-06-08-43-18 002" src="https://github.com/user-attachments/assets/17905fac-8fca-43fb-bc69-ce57830aebe5" />

### 전광판 (@backoffice/screen)
- 테이블 헤더 정보 추가 및 디자인 개선
  - 컬럼별 정보 이해를 돕기 위해 "주식이름", "현재가격", "변동정보", "남은수량" 헤더 추가
  - grid로 바꿀까 고려해봤으나 시간 상 우선 flex 유지, 추후 그리드로 바꾸겠습니다.


|QR 모드|주식 정보 모드|
|---|---|
|<img src="https://github.com/user-attachments/assets/06edd786-f64d-4f4f-80bc-be8f2b2704e3" width="1000"/>|<img width="1000" alt="KakaoTalk_Photo_2025-03-06-08-43-18 004" src="https://github.com/user-attachments/assets/4abea984-fd81-45cf-a128-f5750862c4e7" />|



### 프로필 페이지 및 투표 모드
- 단순 배경색/폰트색만 변경

|프로필 페이지|투표 모드|
|---|---|
|<img width="200" alt="KakaoTalk_Photo_2025-03-06-08-43-18 005" src="https://github.com/user-attachments/assets/3b1374e7-c159-4fca-adad-c4fdeb194a26" />|<img width="200" alt="KakaoTalk_Photo_2025-03-06-08-43-18 003" src="https://github.com/user-attachments/assets/c189866e-2f47-4792-a992-bd89c0521048" />|

## 기타 개선사항
- 폰트 렌더링 최적화 (-webkit-font-smoothing: antialiased, -moz-osx-font-smoothing: grayscale 추가)
  - 피그마에서 디자인된 폰트와 브라우저 렌더링 간 일관성 확보
- 주식게임 홈 탭의 몇몇 폰트의 font-weight 속성 제거 (DungGeunMo 폰트가 이미 bold해서, 기본 굵기가 좋은 것 같습니다!)
- MobileLayout의 기본 배경색 변경 (#f1f1f1 → '')
- 대출하기 버튼 스타일 disabled 상태 색 반영


